### PR TITLE
Allow to output logs on stdout

### DIFF
--- a/ansible/agendav/settings.php.j2
+++ b/ansible/agendav/settings.php.j2
@@ -25,7 +25,7 @@ $app['encryption.key'] = 'abcdefg';
 $app['csrf.secret'] = 'lkjihgfedcba';
 
 // Log path
-$app['log.path'] = '/var/log/agendav/';
+$app['log.path'] = '/var/log/agendav/' . date('Y-m-d') . '.log';
 
 // Base URL
 $app['caldav.baseurl'] = 'http://localhost:81/cal.php';

--- a/doc/source/admin/configuration.rst
+++ b/doc/source/admin/configuration.rst
@@ -70,7 +70,7 @@ modify,  and start configuring your instance.
 
    Full path where logs will be created. Add a trailing slash. Example::
 
-    $app['log.path'] = '/var/log/agendav/';
+    $app['log.path'] = '/var/log/agendav/' . date('Y-m-d') . '.log';
 
    Make sure the user that runs your web server has write permission on that
    directory.

--- a/web/app/services.php
+++ b/web/app/services.php
@@ -19,7 +19,7 @@
  *  along with AgenDAV.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-$app['monolog.logfile'] = function($app) { return $app['log.path'] . '/' . date('Y-m-d') . '.log'; };
+$app['monolog.logfile'] = function($app) { return $app['log.path']; };
 $app['monolog.level'] = function($app) { return $app['log.level']; };
 $app['locale'] = function($app) { return $app['defaults.language']; };
 

--- a/web/config/default.settings.php
+++ b/web/config/default.settings.php
@@ -34,7 +34,7 @@ $app['db.options'] = [
 $app['csrf.secret'] = 'lkjihgfedcba';
 
 // Log path
-$app['log.path'] = __DIR__.'/../var/log/';
+$app['log.path'] = __DIR__.'/../var/log/' . date('Y-m-d') . '.log';
 
 // Logging level
 $app['log.level'] = 'INFO';

--- a/web/src/Log.php
+++ b/web/src/Log.php
@@ -43,7 +43,7 @@ class Log
     {
         $logger = new \Monolog\Logger('http');
         $handler = new \Monolog\Handler\StreamHandler(
-            $log_path . 'http-'. date('Y-m-d') .'.log',
+            $log_path,
             \Monolog\Logger::DEBUG
         );
         $formatter = new \Monolog\Formatter\LineFormatter(


### PR DESCRIPTION
This way we can put logs on standart output too.
For backward compatibility, I changed the default "log.path" by the old way to do.